### PR TITLE
Add customizable mesh gradient colors and UI pickers

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,6 +88,26 @@
                 <label>Text</label>
                 <div id="textColorPicker" class="color-swatch"></div>
             </div>
+
+            <div class="color-picker-group">
+                <label>Color 1</label>
+                <div id="colorValue1Picker" class="color-swatch"></div>
+            </div>
+
+            <div class="color-picker-group">
+                <label>Color 2</label>
+                <div id="colorValue2Picker" class="color-swatch"></div>
+            </div>
+
+            <div class="color-picker-group">
+                <label>Color 3</label>
+                <div id="colorValue3Picker" class="color-swatch"></div>
+            </div>
+
+            <div class="color-picker-group">
+                <label>Color 4</label>
+                <div id="colorValue4Picker" class="color-swatch"></div>
+            </div>
         </div>
     </div>
 

--- a/shaders/main.frag
+++ b/shaders/main.frag
@@ -1,20 +1,43 @@
-precision mediump float;
+ precision mediump float;
 
-uniform vec2 u_resolution;
-uniform float u_time;
+ uniform vec2 u_resolution;
+ uniform float u_time;
 uniform vec2 u_point1;
 uniform vec2 u_point2;
 uniform vec2 u_point3;
 uniform vec2 u_point4;
 
+// Function to convert hex color to RGB vec3
+// Usage: hexToRGB(0x6C2EA9) or hexToRGB(7087785.0) for #6C2EA9
+vec3 hexToRGB(float hex) {
+    float r = floor(hex / 65536.0);
+    float g = floor((hex - r * 65536.0) / 256.0);
+    float b = hex - r * 65536.0 - g * 256.0;
+    return vec3(r, g, b) / 255.0;
+}
+
+// Alternative function using individual RGB components
+// Usage: rgb(108, 46, 169) for #6C2EA9
+vec3 rgb(float r, float g, float b) {
+    return vec3(r, g, b) / 255.0;
+}
+
 void main() {
     vec2 uv = gl_FragCoord.xy / u_resolution.xy;
     
-    // Define 4 corner colors (vibrant colors as requested)
-    vec3 colorTopLeft = vec3(0.0, 0.4, 1.0);     // Vibrant Blue
-    vec3 colorTopRight = vec3(1.0, 0.2, 0.2);    // Vibrant Red
-    vec3 colorBottomLeft = vec3(1.0, 0.6, 0.0);  // Vibrant Orange
-    vec3 colorBottomRight = vec3(1.0, 0.9, 0.0); // Vibrant Yellow
+    // Define 4 corner colors using hex values
+    // Hex colors: #6C2EA9, #1F123C, #250844, #495C91
+    
+    vec3 colorTopLeft = hexToRGB(7087785.0);     // #6C2EA9 (Purple)
+    vec3 colorTopRight = hexToRGB(2036284.0);    // #1F123C (Dark Blue)
+    vec3 colorBottomLeft = hexToRGB(2427972.0);  // #250844 (Dark Purple)
+    vec3 colorBottomRight = hexToRGB(4807825.0); // #495C91 (Blue-Gray)
+    
+    // Alternative syntax using rgb() function:
+    // vec3 colorTopLeft = rgb(108.0, 46.0, 169.0);     // #6C2EA9
+    // vec3 colorTopRight = rgb(31.0, 18.0, 60.0);      // #1F123C
+    // vec3 colorBottomLeft = rgb(37.0, 8.0, 68.0);     // #250844
+    // vec3 colorBottomRight = rgb(73.0, 92.0, 145.0);  // #495C91
     
  
     
@@ -48,7 +71,7 @@ void main() {
     finalColor /= totalWeight;
     
     // Add thin grain effect
-    float grain = fract(sin(dot(uv + u_time * 0.0001, vec2(12.9898, 78.233))) * 43758.5453);
+    float grain = fract(sin(dot(uv + u_time * 0.01, vec2(12.9898, 78.233))) * 43758.5453);
     grain = (grain - 0.5) * 0.05; // Thin grain intensity (12% of full range)
     finalColor += grain;
     
@@ -57,3 +80,149 @@ void main() {
     
     gl_FragColor = vec4(finalColor, 1.0);
 }
+
+// #define PI 3.14159265
+
+// // The x and y coordinates of the camera while at postion z. Also used as the center of the tunnel at position z
+// vec2 path(float z){
+//     return vec2(.5*sin(z), .5*sin(z*.7));
+// }
+
+// // Distance to the edge of the tunnel
+// float map(vec3 p) {
+//     float d = -length(p.xy - path(p.z)) + 1.2 + .3 * sin(p.z*.4);
+//     return d;
+// }
+
+// // Normal of distance function using forward differences
+// vec3 normal(vec3 p){
+//     float d = map(p);
+//     vec2 e = vec2(0.01, 0.0);
+
+//     vec3 n = d - vec3(
+//         map(p - e.xyy),
+//         map(p - e.yxy),
+//         map(p - e.yyx)
+//     );
+
+//     return normalize(n);
+// }
+
+// // Smooth maximum function
+// float sMax(float a, float b, float k) {
+//     return log(exp(k*a) + exp(k*b)) / k;
+// }
+
+// // Bump map, gives the height of the tiles
+// float bumpFunction(vec3 p) {
+//     vec2 c = path(p.z);
+//     float id = floor(p.z*4.-.25); 
+//     float h = .5 + .5*sin(atan(p.y - c.y, p.x - c.x) * 20. + 1.5 * (2.*mod(id, 2.)-1.) + u_time * 5.);
+//     h = sMax(h, .5 + .5*sin(p.z *8.*PI), 16.);
+//     h *= h;
+//     h *= h*h;
+//     return 1.-h;
+// }
+
+// // Calculate normal of the bump map using central differences and add this to the normal of the tunnel
+// vec3 bumpNormal(vec3 p, vec3 n, float bumpFactor) {
+//     vec3 e = vec3(0.01, 0.0, 0.0);
+
+//     float f  = bumpFunction(p);
+//     float fx = bumpFunction(p - e.xyy);
+//     float fy = bumpFunction(p - e.yxy);
+//     float fz = bumpFunction(p - e.yyx);
+//     // Forward difference gradient (cheaper alternative)
+//     //vec3 grad = vec3(fx - f, fy - f, fz - f) / e.x;
+    
+//     float fx2 = bumpFunction(p + e.xyy);
+//     float fy2 = bumpFunction(p + e.yxy);
+//     float fz2 = bumpFunction(p + e.yyx);
+//     // Central difference gradient
+//     vec3 grad = (vec3(fx - fx2, fy - fy2, fz - fz2)) / (e.x * 2.0);
+
+//     // Remove normal component so we only perturb tangentially
+//     grad -= n * dot(n, grad);
+
+//     // Combine with original normal
+//     return normalize(n + grad * bumpFactor);
+// }
+
+// void main()
+// {
+//     vec2 uv = (gl_FragCoord.xy*2. - u_resolution.xy)/u_resolution.y;
+    
+//     // Camera position and camera target follow the path
+//     float vel = u_time * 1.5;
+//     vec3 ro = vec3(path(vel - 1.), vel - 1.);
+//     vec3 ta = vec3(path(vel), vel);
+    
+//     // Set up ray direction
+//     vec3 fwd = normalize(ta - ro);
+//     vec3 up = vec3(0, 1., 0);
+//     vec3 right = cross(fwd, up);;
+//     up = cross(right, fwd);
+//     float fl = 1.2;
+//     vec3 rd = normalize(fwd + fl * (uv.x*right + uv.y*up));
+    
+//     // Set up golden glow
+//     float glow;
+//     vec3 glowCol = vec3(9., 7., 4.);
+    
+//     // Set up raymarching
+//     float t;
+//     vec3 col;
+    
+//     for (int i=0; i<125; i++){
+//         vec3 p = ro + t*rd;
+//         float d = map(p);
+        
+//         // Add glow each step based on distance to edge tunnel
+//         glow += exp(-d * 8.) * .005;
+        
+//         if (d<.01){
+//             // Get light direction from normal, then distort normal for the tiles
+//             vec3 n = normal(p);
+//             vec3 lightDir = n;
+//             n = bumpNormal(p, n, .02);
+            
+//             // Get ring and angle of position
+//             vec2 c = path(p.z);
+//             vec2 id = vec2(floor(p.z*4.-.25), atan(p.y-c.y, p.x-c.x));
+            
+            
+//             // Set the color of the tile based on the id
+//             vec3 tileCol = vec3(.7);
+//             tileCol += .4*vec3(sin(id.x), cos(id.x), 0);
+//             tileCol += .3*sin(id.x*.5 + id.y*6. - u_time*4.);
+//             vec3 tileGray  = vec3(.5);
+//             float height = bumpFunction(p);
+//             vec3 baseCol = mix(tileGray, tileCol, height);
+            
+//             // Lighting: diffuse, specular and reflected light
+//             float diffuseL = max(dot(n, lightDir), 0.);
+//             col += diffuseL * baseCol;
+            
+//             vec3 h = normalize(lightDir - rd);
+//             float specL = pow(max(dot(n, h), 0.), 64.);
+//             col += specL * .3;
+            
+//             vec3 r = reflect(rd, n);
+//             vec3 reflCol = vec3(0.0);
+//             col = mix(col, reflCol, .3);
+            
+//             break;
+//         }
+        
+//         t+=d;
+//     }
+    
+//     // Add the golden glow
+//     col += glowCol*glow;
+    
+//     // Gamma correction
+//     col=pow(col, vec3(2.2));
+    
+//     // Output to screen
+//      gl_FragColor = vec4(col,1.0);
+// }

--- a/shaders/mesh-gradient.frag
+++ b/shaders/mesh-gradient.frag
@@ -1,0 +1,80 @@
+precision mediump float;
+
+uniform vec2 u_resolution;
+uniform float u_time;
+
+uniform vec3 u_color1;
+uniform vec3 u_color2;
+uniform vec3 u_color3;
+uniform vec3 u_color4;
+
+
+
+// Alternative function using individual RGB components
+vec3 rgb(float r, float g, float b) {
+    return vec3(r, g, b) / 255.0;
+}
+
+// Distance function for smooth blending
+float sdCircle(vec2 p, float r) {
+    return length(p) - r;
+}
+
+void main() {
+    vec2 uv = gl_FragCoord.xy / u_resolution.xy;
+    vec2 st = uv * 2.0 - 1.0;
+    st.x *= u_resolution.x / u_resolution.y;
+    
+    // Colors are now passed as uniforms from JavaScript:
+    // u_color1, u_color2, u_color3, u_color4
+    
+    // Create animated mesh points
+    float time = u_time * 0.3;
+    
+    // Define 4 mesh control points with animation
+    vec2 point1 = vec2(sin(time * 0.7) * 0.6, cos(time * 0.5) * 0.4);
+    vec2 point2 = vec2(cos(time * 0.8 + 1.5) * 0.5, sin(time * 0.6 + 2.0) * 0.6);
+    vec2 point3 = vec2(sin(time * 0.9 + 3.0) * 0.4, cos(time * 0.7 + 1.0) * 0.5);
+    vec2 point4 = vec2(cos(time * 0.6 + 4.0) * 0.6, sin(time * 0.8 + 3.5) * 0.4);
+    
+    // Calculate distances to each point
+    float dist1 = length(st - point1);
+    float dist2 = length(st - point2);
+    float dist3 = length(st - point3);
+    float dist4 = length(st - point4);
+    
+    // Create smooth falloff for each point (inverse squared distance weighting)
+    float falloff = 2.0; // Controls blend radius
+    float weight1 = 1.0 / (1.0 + dist1 * dist1 * falloff);
+    float weight2 = 1.0 / (1.0 + dist2 * dist2 * falloff);
+    float weight3 = 1.0 / (1.0 + dist3 * dist3 * falloff);
+    float weight4 = 1.0 / (1.0 + dist4 * dist4 * falloff);
+    
+    // Normalize weights
+    float totalWeight = weight1 + weight2 + weight3 + weight4;
+    weight1 /= totalWeight;
+    weight2 /= totalWeight;
+    weight3 /= totalWeight;
+    weight4 /= totalWeight;
+    
+    // Blend colors based on weights
+    vec3 finalColor = u_color1 * weight1 + 
+                     u_color2 * weight2 + 
+                     u_color3 * weight3 + 
+                     u_color4 * weight4;
+    
+    // Add animated grain effect (matching your main shader)
+    float grain = fract(sin(dot(uv + u_time * 0.01, vec2(12.9898, 78.233))) * 43758.5453);
+    grain = (grain - 0.5) * 0.03; // Subtle grain
+    finalColor += grain;
+    
+    // Add color variation based on position
+    float colorShift = sin(uv.x * 3.14159 + time) * sin(uv.y * 3.14159 + time * 1.3) * 0.1;
+    finalColor += colorShift * u_color1;
+    
+    // Enhance contrast and saturation
+    finalColor = pow(finalColor, vec3(0.9)); // Slight gamma adjustment
+    finalColor = clamp(finalColor, 0.0, 1.0);
+    
+    gl_FragColor = vec4(finalColor, 1.0);
+}

--- a/shaders/shader-manager.js
+++ b/shaders/shader-manager.js
@@ -43,7 +43,7 @@ class ShaderManager {
     async loadShaders() {
         const [vertSrc, fragSrc] = await Promise.all([
             this.loadShaderFile('shaders/main.vert'),
-            this.loadShaderFile('shaders/main.frag')
+            this.loadShaderFile('shaders/mesh-gradient.frag')
         ]);
 
         const program = this.createShaderProgram(vertSrc, fragSrc);
@@ -56,6 +56,10 @@ class ShaderManager {
         this.uniforms.set('u_point2', this.gl.getUniformLocation(program, 'u_point2'));
         this.uniforms.set('u_point3', this.gl.getUniformLocation(program, 'u_point3'));
         this.uniforms.set('u_point4', this.gl.getUniformLocation(program, 'u_point4'));
+        this.uniforms.set('u_color1', this.gl.getUniformLocation(program, 'u_color1'));
+        this.uniforms.set('u_color2', this.gl.getUniformLocation(program, 'u_color2'));
+        this.uniforms.set('u_color3', this.gl.getUniformLocation(program, 'u_color3'));
+        this.uniforms.set('u_color4', this.gl.getUniformLocation(program, 'u_color4'));
 
         // Set up vertex buffer
         this.setupVertexBuffer();
@@ -199,7 +203,7 @@ class ShaderManager {
     updateNoisePoints(time) {
         if (!this.noise) return;
 
-        this.timeOffset = time * 0.1; // Slow movement
+        this.timeOffset = time * 0.01; // Slow movement
 
         // Update each point with noise
         for (let i = 0; i < this.points.length; i++) {
@@ -223,6 +227,20 @@ class ShaderManager {
         const gl = this.gl;
         const program = this.programs.get('main');
 
+
+        const color1 = window.UIController.getColor1Value();
+        const color2 = window.UIController.getColor2Value();
+        const color3 = window.UIController.getColor3Value();
+        const color4 = window.UIController.getColor4Value();
+
+        // Normalize colors from 0-255 to 0-1 range for WebGL
+        const normalizedColor1 = { r: color1.r / 255.0, g: color1.g / 255.0, b: color1.b / 255.0 };
+        const normalizedColor2 = { r: color2.r / 255.0, g: color2.g / 255.0, b: color2.b / 255.0 };
+        const normalizedColor3 = { r: color3.r / 255.0, g: color3.g / 255.0, b: color3.b / 255.0 };
+        const normalizedColor4 = { r: color4.r / 255.0, g: color4.g / 255.0, b: color4.b / 255.0 };
+
+        console.log('Original colors (0-255):', color1, color2, color3, color4);
+        console.log('Normalized colors (0-1):', normalizedColor1, normalizedColor2, normalizedColor3, normalizedColor4);
         if (!program) return;
 
         // Update noise-based points
@@ -247,6 +265,12 @@ class ShaderManager {
         gl.uniform2f(this.uniforms.get('u_point2'), this.points[1].x, this.points[1].y);
         gl.uniform2f(this.uniforms.get('u_point3'), this.points[2].x, this.points[2].y);
         gl.uniform2f(this.uniforms.get('u_point4'), this.points[3].x, this.points[3].y);
+
+
+        gl.uniform3f(this.uniforms.get('u_color1'), normalizedColor1.r, normalizedColor1.g, normalizedColor1.b);
+        gl.uniform3f(this.uniforms.get('u_color2'), normalizedColor2.r, normalizedColor2.g, normalizedColor2.b);
+        gl.uniform3f(this.uniforms.get('u_color3'), normalizedColor3.r, normalizedColor3.g, normalizedColor3.b);
+        gl.uniform3f(this.uniforms.get('u_color4'), normalizedColor4.r, normalizedColor4.g, normalizedColor4.b);
 
         // Set up vertex attributes
         gl.bindBuffer(gl.ARRAY_BUFFER, this.vertexBuffer);

--- a/ui-controller.js
+++ b/ui-controller.js
@@ -8,11 +8,15 @@ let typingInfo;
 
 // Color picker elements
 let bgColorPicker, textColorPicker, swapColorsBtn;
-let bgPickr, textPickr;
+let bgPickr, textPickr, colorValue1Picker, colorValue2Picker, colorValue3Picker, colorValue4Picker;
 
 // Color state
 let backgroundColor = '#ffffff';
 let textColor = '#000000';
+let color1 = '#6C2EA9';
+let color2 = '#1F123C';
+let color3 = '#250844';
+let color4 = '#495C91';
 
 // State variables (managed by main.js)
 // These are initialized by main.js and passed to initUI()
@@ -51,6 +55,11 @@ function initUI(initialWords, initialUserHasTyped, initialWdt) {
     bgColorPicker = document.getElementById('bgColorPicker');
     textColorPicker = document.getElementById('textColorPicker');
     swapColorsBtn = document.getElementById('swapColorsBtn');
+
+    colorValue1Picker = document.getElementById('colorValue1Picker');
+    colorValue2Picker = document.getElementById('colorValue2Picker');
+    colorValue3Picker = document.getElementById('colorValue3Picker');
+    colorValue4Picker = document.getElementById('colorValue4Picker');
 
     // Initialize text input with default text
     textInput.value = words;
@@ -132,6 +141,9 @@ function initColorPickers() {
         }
     });
 
+
+
+
     // Initialize text color picker
     textPickr = Pickr.create({
         el: '#textColorPicker',
@@ -144,10 +156,64 @@ function initColorPickers() {
         }
     });
 
+    // Initialize color 1 picker
+
+    colorValue1Picker = Pickr.create({
+        el: '#colorValue1Picker',
+        theme: 'classic',
+        default: color1,
+        components: {
+            preview: true,
+            hue: true,
+            interaction: { input: true }
+        }
+    });
+    // Initialize color 2 picker
+
+    colorValue2Picker = Pickr.create({
+        el: '#colorValue2Picker',
+        theme: 'classic',
+        default: color2,
+        components: {
+            preview: true,
+            hue: true,
+            interaction: { input: true }
+        }
+    });
+
+    // Initialize color 3 picker
+
+    colorValue3Picker = Pickr.create({
+        el: '#colorValue3Picker',
+        theme: 'classic',
+        default: color3,
+        components: {
+            preview: true,
+            hue: true,
+            interaction: { input: true }
+        }
+    });
+
+    // Initialize color 4 picker
+
+    colorValue4Picker = Pickr.create({
+        el: '#colorValue4Picker',
+        theme: 'classic',
+        default: color4,
+        components: {
+            preview: true,
+            hue: true,
+            interaction: { input: true }
+        }
+    });
+
     // Set initial colors
     bgPickr.setColor(backgroundColor);
     textPickr.setColor(textColor);
-
+    colorValue1Picker.setColor(color1);
+    colorValue2Picker.setColor(color2);
+    colorValue3Picker.setColor(color3);
+    colorValue4Picker.setColor(color4);
     // Add event listeners
     bgPickr.on('change', (color) => {
         backgroundColor = color.toHEXA().toString();
@@ -155,6 +221,22 @@ function initColorPickers() {
 
     textPickr.on('change', (color) => {
         textColor = color.toHEXA().toString();
+    });
+
+    colorValue1Picker.on('change', (color) => {
+        color1 = color.toHEXA().toString();
+    });
+
+    colorValue2Picker.on('change', (color) => {
+        color2 = color.toHEXA().toString();
+    });
+
+    colorValue3Picker.on('change', (color) => {
+        color3 = color.toHEXA().toString();
+    });
+
+    colorValue4Picker.on('change', (color) => {
+        color4 = color.toHEXA().toString();
     });
 }
 
@@ -167,6 +249,10 @@ function swapColors() {
     // Update pickers
     bgPickr.setColor(backgroundColor);
     textPickr.setColor(textColor);
+    colorValue1Picker.setColor(color1);
+    colorValue2Picker.setColor(color2);
+    colorValue3Picker.setColor(color3);
+    colorValue4Picker.setColor(color4);
 }
 
 // Update slider value displays
@@ -234,6 +320,21 @@ function getCurrentState() {
     };
 }
 
+function hexToRgb(hex) {
+    // Expand shorthand form (e.g. "03F") to full form (e.g. "0033FF")
+    var shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
+    hex = hex.replace(shorthandRegex, function (m, r, g, b) {
+        return r + r + g + g + b + b;
+    });
+
+    var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+    return result ? {
+        r: parseInt(result[1], 16),
+        g: parseInt(result[2], 16),
+        b: parseInt(result[3], 16)
+    } : null;
+}
+
 // Get background color
 function getBackgroundColor() {
     return backgroundColor;
@@ -252,6 +353,30 @@ function getSpeedValue() {
 // Get factor value
 function getFactorValue() {
     return 1.4;
+}
+
+// Get color 1 value
+function getColor1Value() {
+    const color = hexToRgb(color1);
+    return color;
+}
+
+// Get color 2 value
+function getColor2Value() {
+    const color = hexToRgb(color2);
+    return color;
+}
+
+// Get color 3 value
+function getColor3Value() {
+    const color = hexToRgb(color3);
+    return color;
+}
+
+// Get color 4 value
+function getColor4Value() {
+    const color = hexToRgb(color4);
+    return color;
 }
 
 // Video export handlers
@@ -340,6 +465,10 @@ window.UIController = {
     getFillColor,
     getSpeedValue,
     getFactorValue,
+    getColor1Value,
+    getColor2Value,
+    getColor3Value,
+    getColor4Value,
     getWords: () => words,
     getUserHasTyped: () => userHasTyped,
     getWdt: () => wdt,


### PR DESCRIPTION
Introduces four new color pickers in the UI for mesh gradient customization. Adds a new mesh-gradient.frag shader that blends four colors passed as uniforms. Updates shader-manager.js to load the new shader and pass normalized color values from UIController. Implements color value getters and hex-to-RGB conversion in ui-controller.js, enabling real-time color changes for the mesh gradient effect.